### PR TITLE
Aruba should not be a runtime dep

### DIFF
--- a/appraisal.gemspec
+++ b/appraisal.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('cucumber', '~> 1.0')
   s.add_development_dependency('rspec', '~> 2.6')
-
+  s.add_development_dependency('aruba', '~> 0.4.2')
+  
   s.add_runtime_dependency('rake')
   s.add_runtime_dependency('bundler')
-  s.add_runtime_dependency('aruba', '~> 0.4.2')
 
   s.platform = Gem::Platform::RUBY
   s.rubygems_version = %q{1.2.0}


### PR DESCRIPTION
Not sure why aruba is listed as a runtime dependency. Things seem to work without it and since aruba depends on rspec 2.6 or so there's a big problem if your project uses a different version.
