### PR TITLE
Fix source_entry to work with sources like :rubygems

### DIFF
--- a/lib/appraisal/gemfile.rb
+++ b/lib/appraisal/gemfile.rb
@@ -51,7 +51,7 @@ module Appraisal
     protected
 
     def source_entry
-      %(source "#{@source}")
+      %(source #{@source.inspect})
     end
 
     def dependencies_entry


### PR DESCRIPTION
Addresses issue #8
