### PR TITLE
Gemspec source as symbol

### DIFF
--- a/features/gemspec.feature
+++ b/features/gemspec.feature
@@ -68,3 +68,15 @@ Scenario: run a gem in the gemspec via path
   When I run `bundle exec rake appraisal version --trace`
   Then the output should contain "Loaded 1.3.0"
 
+
+@disable-bundler
+Scenario: run a gem in the gemspec with source-as-symbol
+  And I write to "Gemfile" with:
+  """
+  source :rubygems
+  gemspec
+  """
+  When I add "appraisal" from this project as a dependency
+  When I successfully run `bundle exec rake appraisal:install --trace`
+  When I run `bundle exec rake appraisal version --trace`
+  Then the output should contain "Loaded 1.3.2"

--- a/lib/appraisal/gemfile.rb
+++ b/lib/appraisal/gemfile.rb
@@ -51,7 +51,11 @@ module Appraisal
     protected
 
     def source_entry
-      %(source "#{@source}")
+      if @source.is_a?(Symbol)
+        %(source :#{@source})
+      else
+        %(source "#{@source}")
+      end
     end
 
     def dependencies_entry


### PR DESCRIPTION
Some Gemfiles declare the gem source as a symbol, e.g.:

```
source :rubygems
```

This patch adds a test and support for this use case.
