### PR TITLE
Support ENV['BUNDLE_GEMFILE'] variable

### DIFF
--- a/lib/appraisal/file.rb
+++ b/lib/appraisal/file.rb
@@ -13,7 +13,7 @@ module Appraisal
     def initialize
       @appraisals = []
       @gemfile = Gemfile.new
-      @gemfile.load('Gemfile')
+      @gemfile.load(ENV['BUNDLE_GEMFILE'] || 'Gemfile')
       run(IO.read(path)) if ::File.exists?(path)
     end
 


### PR DESCRIPTION
This is because this could _potentially_ be set to something other than Gemfile.

For example, in Spree, we have a dummy application that lives at spec/dummy inside each engine component. Each engine component has a Gemfile at the root of its directory. The dummy applications contain no Gemfile, and so their config/boot.rb sets the ENV['BUNDLE_GEMFILE'] path to go back up to the root's Gemfile.

Appraisal doesn't acknowledge this environment variable, but should.
