### PR TITLE
Bundler's group method can take multiple group names, appraisal breaks this

### DIFF
--- a/lib/appraisal/gemfile.rb
+++ b/lib/appraisal/gemfile.rb
@@ -24,7 +24,7 @@ module Appraisal
       @dependencies << Dependency.new(name, requirements)
     end
 
-    def group(name)
+    def group(*names)
       # ignore the group
     end
 


### PR DESCRIPTION
Have it take and ignore any number of args (mirroring bundler's api).
