### PR TITLE
Keep dots when generating a Gemfile

### DIFF
--- a/lib/appraisal/appraisal.rb
+++ b/lib/appraisal/appraisal.rb
@@ -48,7 +48,7 @@ module Appraisal
     end
 
     def clean_name
-      name.gsub(/\s+/, '_').gsub(/[^\w]/, '')
+      name.gsub(/[^\w\.]/, '_')
     end
   end
 end

--- a/spec/appraisal/appraisal_spec.rb
+++ b/spec/appraisal/appraisal_spec.rb
@@ -9,8 +9,18 @@ describe Appraisal::Appraisal do
     appraisal.bundle_command.should == "bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory'"
   end
 
-  it "cleans up spaces and punctuation when outputting its gemfile" do
-    appraisal = Appraisal::Appraisal.new("This! is my appraisal name.", "Gemfile")
-    appraisal.gemfile_path.should =~ /This_is_my_appraisal_name.gemfile/
+  it "converts spaces to underscores in the gemfile path" do
+    appraisal = Appraisal::Appraisal.new("one two", "Gemfile")
+    appraisal.gemfile_path.should =~ /one_two\.gemfile$/
+  end
+
+  it "converts  punctuation to underscores in the gemfile path" do
+    appraisal = Appraisal::Appraisal.new("o&ne!", "Gemfile")
+    appraisal.gemfile_path.should =~ /o_ne_\.gemfile$/
+  end
+
+  it "keeps dots in the gemfile path" do
+    appraisal = Appraisal::Appraisal.new("rails3.0", "Gemfile")
+    appraisal.gemfile_path.should =~ /rails3\.0\.gemfile$/
   end
 end


### PR DESCRIPTION
This also changes how punctuation that isn't "." is treated. Previously, it
would be removed, now it is converted to "_". Thus, `appraise "rails3.0!"` now
generates "rails3.0_.gemfile" where before it generated "rails30.gemfile".
