### PR TITLE
Command determines ARGV correctly when ARGV empty

### DIFF
--- a/lib/appraisal/command.rb
+++ b/lib/appraisal/command.rb
@@ -4,8 +4,16 @@ module Appraisal
     BUNDLER_ENV_VARS = %w(RUBYOPT BUNDLE_PATH BUNDLE_BIN_PATH BUNDLE_GEMFILE).freeze
 
     def self.from_args(gemfile)
-      command = ([$0] + ARGV.slice(1, ARGV.size)).join(' ')
+      command = ([$0] + args_after_appraisal).join(' ')
       new(command, gemfile)
+    end
+
+    def self.args_after_appraisal
+      args = ARGV.dup
+      if args[0] == 'appraisal'
+        args.delete_at(0)
+      end
+      args
     end
 
     def initialize(command, gemfile = nil)


### PR DESCRIPTION
Usually if you call `rake appraisal` from a project configured to use Appraisal, then everything works -- Appraisal calls `rake` for each of your gemfiles.

However, if you've configured `rake` to run `rake appraisal` automatically, when you call `rake` then Appraisal::Command throws an error. This is because it assumes that "appraisal" will be first in ARGV, which is the case when you call `rake appraisal` manually but not the case here. Therefore when it tries to figure out which command to run it blows up (as ARGV[1..-1] returns nil if ARGV is empty). This commit fixes that.

NOTE: I'm not sure how to test this? Is there a way?
