### PR TITLE
Add bundler parallel install option

### DIFF
--- a/appraisal.gemspec
+++ b/appraisal.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Find out what your Ruby gems are worth}
   s.description = %q{Appraisal integrates with bundler and rake to test your library against different versions of dependencies in repeatable scenarios called "appraisals."}
   s.license     = 'MIT'
-  
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('rake')
   s.add_runtime_dependency('bundler')
+  s.add_runtime_dependency('parallel')
 
   s.add_development_dependency('activesupport', '>= 3.2.13')
   s.add_development_dependency('cucumber', '~> 1.0')

--- a/lib/appraisal/appraisal.rb
+++ b/lib/appraisal/appraisal.rb
@@ -1,6 +1,7 @@
 require 'appraisal/gemfile'
 require 'appraisal/command'
 require 'fileutils'
+require 'parallel'
 
 module Appraisal
   # Represents one appraisal and its dependencies
@@ -53,7 +54,7 @@ module Appraisal
 
     def bundle_parallel_option
       if Gem::Version.create(Bundler::VERSION) >= Gem::Version.create('1.4.0.pre.1')
-        '--jobs=4'
+        "--jobs=#{::Parallel.processor_count}"
       end
     end
   end

--- a/spec/appraisal/appraisal_spec.rb
+++ b/spec/appraisal/appraisal_spec.rb
@@ -6,7 +6,7 @@ describe Appraisal::Appraisal do
   it "creates a proper bundle command" do
     appraisal = Appraisal::Appraisal.new('fake', 'fake')
     appraisal.stub(:gemfile_path).and_return("/home/test/test directory")
-    appraisal.stub(:bundle_parallel_option).and_return(nil)
+    stub_const('Bundler::VERSION', '1.3.0')
 
     appraisal.bundle_command.should == "bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory'"
   end
@@ -15,8 +15,9 @@ describe Appraisal::Appraisal do
     appraisal = Appraisal::Appraisal.new('fake', 'fake')
     appraisal.stub(:gemfile_path).and_return("/home/test/test directory")
     stub_const('Bundler::VERSION', '1.4.0')
+    Parallel.stub(:processor_count).and_return(42)
 
-    appraisal.bundle_command.should == "bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory' --jobs=4"
+    appraisal.bundle_command.should == "bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory' --jobs=42"
   end
 
   it "converts spaces to underscores in the gemfile path" do


### PR DESCRIPTION
`bundler v1.4.0.pre.1` acquires parallel bundle install. This makes `appraisal:install` faster!
