### PR TITLE
Add description of known Bundle installation limitation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ In your Gemfile:
 
     gem "appraisal"
 
+Note that gems must be bundled in the global namespace. Bundling gems to a local 
+location or vendoring plugins is not supported. If you do not want to pollute the
+global namespace, one alternative is [RVM's Gemsets](http://rvm.io/gemsets).
+
 Setup
 -----
 


### PR DESCRIPTION
Appraisal seems to require Bundler to install the requirements of the Gemfile in the global namespace, see #13 and #30.
