### PR TITLE
Updating CLI for MRI 1.8 friendliness

### DIFF
--- a/lib/appraisal/cli.rb
+++ b/lib/appraisal/cli.rb
@@ -36,8 +36,9 @@ module Appraisal
     end
 
     desc 'install', 'Resolve and install dependencies for each appraisal'
-    method_option 'jobs', aliases: 'j', type: :numeric, default: 1, banner: 'SIZE',
-      desc: 'Install gems in parallel using the given number of workers.'
+    method_option 'jobs', :aliases => 'j', :type => :numeric, :default => 1,
+      :banner => 'SIZE',
+      :desc => 'Install gems in parallel using the given number of workers.'
     def install
       invoke :generate, [], {}
 


### PR DESCRIPTION
I know MRI 1.8 is dead, but I have a gem (flying-sphinx) that needs to support apps that still run 1.8, and Appraisal's the best tool for staying on top of that. This was the only thing stopping Appraisal from working.
