### PR TITLE
wwtd

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ all versions of its dependency, you might have to set a `script` setting:
 That will make sure that each of the test sub-job are not getting run more than
 one time.
 
+To run on all rubies / gemfiles, see [WWTD](https://github.com/grosser/wwtd)
+
 Credits
 -------
 


### PR DESCRIPTION
all my projects that use appraisal also get wwtd, so I can be confident in the tests, do not need to wait for travis and make contribution easier (hooked up to `:default`), might be a nice hint

@pat @sikachu
