### PR TITLE
Add 'list' subcommand to CLI

### DIFF
--- a/lib/appraisal/cli.rb
+++ b/lib/appraisal/cli.rb
@@ -69,6 +69,11 @@ module Appraisal
       end
     end
 
+    desc 'list', 'List the names of the defined appraisals'
+    def list
+      File.new.appraisals.each { |appraisal| puts appraisal.name }
+    end
+
     private
 
     def method_missing(name, *args, &block)

--- a/spec/acceptance/cli/list_spec.rb
+++ b/spec/acceptance/cli/list_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'CLI', 'appraisal list' do
+  it 'prints list of appraisals' do
+    build_appraisal_file <<-Appraisal
+      appraise '1.0.0' do
+        gem 'dummy', '1.0.0'
+      end
+      appraise '2.0.0' do
+        gem 'dummy', '1.0.0'
+      end
+      appraise '1.1.0' do
+        gem 'dummy', '1.0.0'
+      end
+    Appraisal
+
+    output = run 'appraisal list'
+
+    expect(output).to eq("1.0.0\n2.0.0\n1.1.0\n")
+  end
+
+  it 'prints nothing if there are no appraisals in the file' do
+    build_appraisal_file ''
+    output = run 'appraisal list'
+
+    expect(output.length).to eq(0)
+  end
+end


### PR DESCRIPTION
For scripting purposes it's usefull to have a simple way to list the appraisals defined in the Appraisals file, this patch adds a subcommand to the CLI for that purpose.
