### PR TITLE
uniq Gemfile#source

### DIFF
--- a/lib/appraisal/gemfile.rb
+++ b/lib/appraisal/gemfile.rb
@@ -97,7 +97,7 @@ module Appraisal
     protected
 
     def source_entry
-      @sources.map { |source| "source #{source.inspect}" }.join("\n")
+      @sources.uniq.map { |source| "source #{source.inspect}" }.join("\n")
     end
 
     def ruby_version_entry

--- a/spec/appraisal/gemfile_spec.rb
+++ b/spec/appraisal/gemfile_spec.rb
@@ -17,6 +17,13 @@ describe Appraisal::Gemfile do
     expect(gemfile.to_s.strip).to eq %{source "one"\nsource "two"}
   end
 
+  it "ignores duplicate sources" do
+    gemfile = Appraisal::Gemfile.new
+    gemfile.source "one"
+    gemfile.source "one"
+    expect(gemfile.to_s.strip).to eq %{source "one"}
+  end
+
   it "preserves dependency order" do
     gemfile = Appraisal::Gemfile.new
     gemfile.gem "one"


### PR DESCRIPTION
I'm author of a library https://github.com/razum2um/lurker with multi-rails suport which I migrate to use appraisal.
I want the lib to be tested and used without appraisal as well, that's why I use regular `Gemfile` for `:development` gems, and I do `eval ::File.read('Gemfile')` to import it into `appraise` section.
I don't want to transfer them to `Appraisal` file as it seems unintuitive to me and prevents proper using without appraisal prefix at all. Currently I'm getting `source` line twice (one evaled from Gemfile)

This fixes it. 
Anyway it doesn't make sense to have identical sources, is it?