### PR TITLE
Compatibility with ruby 1.8.7

### DIFF
--- a/lib/appraisal/appraisal.rb
+++ b/lib/appraisal/appraisal.rb
@@ -65,7 +65,7 @@ module Appraisal
 
     def update(gems = [])
       command, env = update_command(gems)
-      Command.new(command, env: env).run
+      Command.new(command, :env => env).run
     end
 
     def gemfile_path

--- a/lib/appraisal/cli.rb
+++ b/lib/appraisal/cli.rb
@@ -86,10 +86,10 @@ module Appraisal
       matching_appraisal = File.new.appraisals.detect { |appraisal| appraisal.name == name.to_s }
 
       if matching_appraisal
-        Command.new(args, gemfile: matching_appraisal.gemfile_path).run
+        Command.new(args, :gemfile => matching_appraisal.gemfile_path).run
       else
         File.each do |appraisal|
-          Command.new(ARGV, gemfile: appraisal.gemfile_path).run
+          Command.new(ARGV, :gemfile => appraisal.gemfile_path).run
         end
       end
     end

--- a/lib/appraisal/gemspec.rb
+++ b/lib/appraisal/gemspec.rb
@@ -22,7 +22,7 @@ module Appraisal
 
     def exported_options
       @options.merge(
-        path: Utils.prefix_path(@options[:path])
+        :path => Utils.prefix_path(@options[:path])
       )
     end
   end


### PR DESCRIPTION
Hi,

since 1.0.3 release seems that the gem cannot be used when running ruby 1.8.7. A couple of merged PRs use syntax `foo: bar` instead of `:foo => bar`.

Ex: https://travis-ci.org/rollbar/rollbar-gem/jobs/54759157

This PR fix that, but really don't know if you are interested in this compatibility or not.