### PR TITLE
Add minimal `OrderedHash` and remove runtime activesupport dependency.

### DIFF
--- a/appraisal.gemspec
+++ b/appraisal.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rake')
   s.add_runtime_dependency('bundler')
   s.add_runtime_dependency('thor', '>= 0.14.0')
-  s.add_runtime_dependency("activesupport", ">= 3.2.21")
 
+  s.add_development_dependency("activesupport", ">= 3.2.21")
   s.add_development_dependency('rspec', '~> 3.0')
 end

--- a/lib/appraisal/bundler_dsl.rb
+++ b/lib/appraisal/bundler_dsl.rb
@@ -1,5 +1,5 @@
 require "appraisal/dependency_list"
-require "active_support/ordered_hash"
+require "appraisal/ordered_hash"
 
 module Appraisal
   class BundlerDSL
@@ -13,10 +13,10 @@ module Appraisal
       @ruby_version = nil
       @dependencies = DependencyList.new
       @gemspec = nil
-      @groups = ActiveSupport::OrderedHash.new
-      @platforms = ActiveSupport::OrderedHash.new
-      @git_sources = ActiveSupport::OrderedHash.new
-      @path_sources = ActiveSupport::OrderedHash.new
+      @groups = OrderedHash.new
+      @platforms = OrderedHash.new
+      @git_sources = OrderedHash.new
+      @path_sources = OrderedHash.new
     end
 
     def run(&block)

--- a/lib/appraisal/dependency_list.rb
+++ b/lib/appraisal/dependency_list.rb
@@ -1,10 +1,10 @@
 require 'appraisal/dependency'
-require "active_support/ordered_hash"
+require 'appraisal/ordered_hash'
 
 module Appraisal
   class DependencyList
     def initialize
-      @dependencies = ActiveSupport::OrderedHash.new
+      @dependencies = OrderedHash.new
     end
 
     def add(name, requirements)

--- a/lib/appraisal/ordered_hash.rb
+++ b/lib/appraisal/ordered_hash.rb
@@ -1,0 +1,22 @@
+module Appraisal
+  # An ordered hash implementation for Ruby 1.8.7 compatibility. This is not
+  # a complete implementation, but it covers Appraisal's specific needs.
+  class OrderedHash < ::Hash
+    # Hashes are ordered in Ruby 1.9.
+    if RUBY_VERSION < '1.9'
+      def initialize(*args, &block)
+        super
+        @keys = []
+      end
+
+      def []=(key, value)
+        @keys << key unless has_key?(key)
+        super
+      end
+
+      def values
+        @keys.collect { |key| self[key] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
As discussed in #94, this PR adds a basic `OrderedHash` and makes `activesupport` a development dependency rather than a runtime one.