### PR TITLE
Add support for bundler's retry flag

### DIFF
--- a/lib/appraisal/cli.rb
+++ b/lib/appraisal/cli.rb
@@ -41,11 +41,13 @@ module Appraisal
     method_option 'jobs', :aliases => 'j', :type => :numeric, :default => 1,
       :banner => 'SIZE',
       :desc => 'Install gems in parallel using the given number of workers.'
+    method_option 'retry', :type => :numeric, :default => 1,
+      :desc => 'Retry network and git requests that have failed'
     def install
       invoke :generate, [], {}
 
       AppraisalFile.each do |appraisal|
-        appraisal.install(options[:jobs])
+        appraisal.install(options)
         appraisal.relativize
       end
     end

--- a/spec/appraisal/appraisal_spec.rb
+++ b/spec/appraisal/appraisal_spec.rb
@@ -41,7 +41,7 @@ describe Appraisal::Appraisal do
       stub_const('Bundler::VERSION', '1.3.0')
 
       warning = capture(:stderr) do
-        @appraisal.install(42)
+        @appraisal.install("jobs" => 42)
       end
 
       expect(Appraisal::Command).to have_received(:new).
@@ -52,10 +52,17 @@ describe Appraisal::Appraisal do
     it 'runs parallel install command on Bundler >= 1.4.0' do
       stub_const('Bundler::VERSION', '1.4.0')
 
-      @appraisal.install(42)
+      @appraisal.install("jobs" => 42)
 
       expect(Appraisal::Command).to have_received(:new).
         with("#{bundle_check_command} || #{bundle_parallel_install_command}")
+    end
+
+    it 'runs install command with retries on Bundler' do
+      @appraisal.install("retry" => 3)
+
+      expect(Appraisal::Command).to have_received(:new).
+        with("#{bundle_check_command} || #{bundle_install_command_with_retries}")
     end
 
     def bundle_check_command
@@ -68,6 +75,10 @@ describe Appraisal::Appraisal do
 
     def bundle_parallel_install_command
       "bundle install --gemfile='/home/test/test directory' --jobs=42"
+    end
+
+    def bundle_install_command_with_retries
+      "bundle install --gemfile='/home/test/test directory' --retry 3"
     end
   end
 end


### PR DESCRIPTION
I ran into the need to run `appraisal install` with a `--retry 3` flag supported by bundler, but it was not supported. This change adds support for it, and prepares for adding any of the other [Bundler flags](http://bundler.io/v1.5/bundle_install.html) that people may want to pass through.