### PR TITLE
Update README.md to add appraisal in gemspec instead of Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
 
 In your package's .gemspec:
 
-   s.add_development_dependency 'appraisal'
+   s.add_development_dependency "appraisal"
 
 Note that gems must be bundled in the global namespace. Bundling gems to a
 local location or vendoring plugins is not supported. If you do not want to

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ without interfering with day-to-day development using Bundler.
 Installation
 ------------
 
-In your Gemfile:
+In your package's .gemspec:
 
-    gem "appraisal"
+   s.add_development_dependency 'appraisal'
 
 Note that gems must be bundled in the global namespace. Bundling gems to a
 local location or vendoring plugins is not supported. If you do not want to


### PR DESCRIPTION
I'm not really sure if this is the right thing to do, so this is more of an RFC. I was just trying to set up appraisal in a gem that was created a year ago and the instructions weren't working.