### PR TITLE
Remove bad advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,6 @@ your `Gemfile`, so you don't need to repeat anything that's the same for each
 appraisal. If something is specified in both the Gemfile and an appraisal, the
 version from the appraisal takes precedence.
 
-It's also recommended that you setup bundler at the very top of your Rakefile,
-so that you don't need to constantly run bundle exec:
-
-    require "rubygems"
-    require "bundler/setup"
-
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ Usage
 Once you've configured the appraisals you want to use, you need to install the
 dependencies for each appraisal:
 
-    $ appraisal install
+    $ bundle exec appraisal install
 
 This will resolve, install, and lock the dependencies for that appraisal using
 bundler. Once you have your dependencies set up, you can run any command in a
 single appraisal:
 
-    $ appraisal rails-3 rake test
+    $ bundle exec appraisal rails-3 rake test
 
 This will run `rake test` using the dependencies configured for Rails 3. You can
 also run each appraisal in turn:
 
-    $ appraisal rake test
+    $ bundle exec appraisal rake test
 
 If you want to use only the dependencies from your Gemfile, just run `rake
 test` as normal. This allows you to keep running with the latest versions of


### PR DESCRIPTION
Trick to not need to add `bundle exec` to commands if you add 2 lines to the Rakefile is flawed.

**Multiple versions of rake**

It does not help at all if you have multiple versions of rake installed.

```
∴ rake
rake aborted!
Gem::LoadError: You have already activated rake 12.0.0, but your Gemfile requires rake 11.2.2. Prepending `bundle exec` to your command may solve this.
∴ gem list rake

*** LOCAL GEMS ***

rake (12.0.0, 11.2.2, 11.1.2, 10.5.0, 10.4.2, 10.1.0, 10.0.4, default: 0.9.6)
```
**Different Package Manager**

It prescribes `rubygems` which is but one among several options for package managers.

**Other use cases**

Not all roads lead through the `Rakefile`, and sometimes `bundle exec` may still be required.  Better to keep things consistent.  If it is trouble to type so much shell aliases are an alternative.
