### PR TITLE
Release version 2.2.0

### DIFF
--- a/lib/appraisal/version.rb
+++ b/lib/appraisal/version.rb
@@ -1,3 +1,3 @@
 module Appraisal
-  VERSION = "2.1.0".freeze
+  VERSION = "2.2.0".freeze
 end


### PR DESCRIPTION
The last release was in August 2015. Comparing [v2.1.0 to master](https://github.com/thoughtbot/appraisal/compare/v2.1.0...master) it looks like the notable functional changes are:

- Display current gemfile when running `bundle update`
- Add support for bundler's `retry` flag
- Add support for bundler's `without` flag
- Add support for multiple gemspec directives

Resolves #127