### PR TITLE
Fix Travis build

### DIFF
--- a/spec/acceptance/bundle_with_custom_path_spec.rb
+++ b/spec/acceptance/bundle_with_custom_path_spec.rb
@@ -29,8 +29,8 @@ describe "Bundle with custom path" do
       run 'bundle exec appraisal install'
 
       installed_gem = Dir.glob("tmp/stage/#{path}/ruby/*/gems/*").
-        map { |path| path.split('/').last }.
-        select { |gem| gem.include?(gem_name) }
+                      map    { |path| path.split('/').last }.
+                      select { |gem| gem.include?(gem_name) }
       expect(installed_gem).not_to be_empty
 
       bundle_output = run 'bundle check'
@@ -42,7 +42,6 @@ describe "Bundle with custom path" do
   end
 
   include_examples :gemfile_dependencies_are_satisfied
-
 
   context 'when already installed in vendor/another' do
     before do

--- a/spec/acceptance/bundle_with_custom_path_spec.rb
+++ b/spec/acceptance/bundle_with_custom_path_spec.rb
@@ -48,7 +48,11 @@ describe "Bundle with custom path" do
       build_gemfile <<-Gemfile
         source "https://rubygems.org"
 
-        gem '#{gem_name}'
+        if RUBY_VERSION <= "1.9"
+          gem '#{gem_name}', '~> 1.6.5'
+        else
+          gem '#{gem_name}'
+        end
       Gemfile
 
       run 'bundle install --path vendor/another'


### PR DESCRIPTION
The command [`appraisal install`](https://github.com/thoughtbot/appraisal/blob/master/spec/acceptance/bundle_with_custom_path_spec.rb#L17) produces a different result locally vs Travis.

locally:
```
>> Reinstall Bundler into tmp/stage/vendor/bundle/ruby/2.3.0
Bundler and RubyGems.org are free for anyone to use, but maintaining them costs more than $25,000 USD every month. Help us cover those costs so that we can keep the gem ecosystem free for everyone: https://ruby.to/support-bundler\nSuccessfully installed bundler-1.14.0
1 gem installed
>> bundle check --gemfile='tmp/stage/gemfiles/breakfast.gemfile' || bundle install --gemfile='mp/stage/gemfiles/breakfast.gemfile' --retry 1
Resolving dependencies...
The Gemfile's dependencies are satisfied

```
vs

Travis:

```
>> bundle check --gemfile='/home/travis/build/berkos/appraisal/tmp/stage/gemfiles/breakfast.gemfile' || bundle install --gemfile='/home/travis/build/berkos/appraisal/tmp/stage/gemfiles/breakfast.gemfile' --retry 1
Resolving dependencies...
The Gemfile's dependencies are satisfied
```
Hypothesis is that newer versions of rvm in travis are installing the bundler as a default gem that cannot be uninstalled. [relevant issue](https://github.com/travis-ci/travis-ci/issues/8717)

Proposal is to check that `bundle install` and `bundle exec appraisal install` produces the same result rather than bundler is installed as a side effect.

@nickcharlton please let me know if I do miss some context.
Thanks!