### PR TITLE
Make git_source work in nested groups

### DIFF
--- a/lib/appraisal/bundler_dsl.rb
+++ b/lib/appraisal/bundler_dsl.rb
@@ -29,12 +29,14 @@ module Appraisal
     end
 
     def group(*names, &block)
-      @groups[names] ||= Group.new(names)
+      @groups[names] ||=
+        Group.new(names).tap { |g| g.git_sources = @git_sources.dup }
       @groups[names].run(&block)
     end
 
     def platforms(*names, &block)
-      @platforms[names] ||= Platform.new(names)
+      @platforms[names] ||=
+        Platform.new(names).tap { |g| g.git_sources = @git_sources.dup }
       @platforms[names].run(&block)
     end
 
@@ -42,7 +44,8 @@ module Appraisal
 
     def source(source, &block)
       if block_given?
-        @source_blocks[source] ||= Source.new(source)
+        @source_blocks[source] ||=
+          Source.new(source).tap { |g| g.git_sources = @git_sources.dup }
         @source_blocks[source].run(&block)
       else
         @sources << source
@@ -54,12 +57,14 @@ module Appraisal
     end
 
     def git(source, options = {}, &block)
-      @gits[source] ||= Git.new(source, options)
+      @gits[source] ||=
+        Git.new(source, options).tap { |g| g.git_sources = @git_sources.dup }
       @gits[source].run(&block)
     end
 
     def path(source, options = {}, &block)
-      @paths[source] ||= Path.new(source, options)
+      @paths[source] ||=
+        Path.new(source, options).tap { |g| g.git_sources = @git_sources.dup }
       @paths[source].run(&block)
     end
 

--- a/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
+++ b/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Appraisals file Bundler DSL compatibility' do
   it 'supports all Bundler DSL in Appraisals file' do
     build_gems %w(bagel orange_juice milk waffle coffee ham sausage pancake)
-    build_git_gems %w(egg croissant pain_au_chocolat)
+    build_git_gems %w(egg croissant pain_au_chocolat omelette)
 
     build_gemfile <<-Gemfile
       source 'https://rubygems.org'
@@ -23,6 +23,7 @@ describe 'Appraisals file Bundler DSL compatibility' do
 
       group :breakfast do
         gem 'orange_juice'
+        gem "omelette", :custom_git_source => "omelette"
       end
 
       platforms :ruby, :jruby do
@@ -106,6 +107,7 @@ describe 'Appraisals file Bundler DSL compatibility' do
 
       group :breakfast do
         gem "orange_juice"
+        gem "omelette", :git => "../../gems/omelette"
         gem "bacon"
 
         platforms :rbx do


### PR DESCRIPTION
- Also make install spec less specific about generated option order.
- Ignore .ruby-version and .ruby-gemset to ease local development.

[Fixes #159]