### PR TITLE
Allow specifying the `path` option to bundler

### DIFF
--- a/lib/appraisal/appraisal.rb
+++ b/lib/appraisal/appraisal.rb
@@ -119,7 +119,11 @@ module Appraisal
     end
 
     def gemfile_root
-      Pathname.new(File.join(Dir.pwd, "gemfiles"))
+      project_root + "gemfiles"
+    end
+
+    def project_root
+      Pathname.new(Dir.pwd)
     end
 
     def gemfile_name
@@ -145,6 +149,12 @@ module Appraisal
           warn 'Your current version of Bundler does not support parallel installation. Please ' +
             'upgrade Bundler to version >= 1.4.0, or invoke `appraisal` without `--jobs` option.'
         end
+      end
+
+      path = full_options.delete("path")
+      if path
+        relative_path = project_root.join(options["path"])
+        options_strings << "--path #{relative_path}"
       end
 
       full_options.each do |flag, val|

--- a/lib/appraisal/cli.rb
+++ b/lib/appraisal/cli.rb
@@ -49,6 +49,10 @@ module Appraisal
     method_option "full-index", :type => :boolean,
                                 :desc => "Run bundle install with the " \
                                          "full-index argument."
+    method_option "path", type: :string,
+                          desc: "Install gems in the specified directory. " \
+                                "Bundler will remember this option."
+
     def install
       invoke :generate, [], {}
 

--- a/spec/acceptance/cli/install_spec.rb
+++ b/spec/acceptance/cli/install_spec.rb
@@ -90,4 +90,23 @@ describe 'CLI', 'appraisal install' do
       )
     end
   end
+
+  context "with path", :parallel do
+    before do
+      build_appraisal_file <<-APPRAISAL
+        appraise '1.0.0' do
+          gem 'dummy', '1.0.0'
+        end
+      APPRAISAL
+    end
+
+    it "accepts --path option to specify the location to install gems into" do
+      output = run("appraisal install --path vendor/appraisal")
+
+      expect(output).to include(
+        "bundle install --gemfile='#{file('gemfiles/1.0.0.gemfile')}' " \
+        "--path #{file('vendor/appraisal')} --retry 1",
+      )
+    end
+  end
 end

--- a/spec/appraisal/appraisal_spec.rb
+++ b/spec/appraisal/appraisal_spec.rb
@@ -34,6 +34,8 @@ describe Appraisal::Appraisal do
     before do
       @appraisal = Appraisal::Appraisal.new('fake', 'fake')
       allow(@appraisal).to receive(:gemfile_path).and_return("/home/test/test directory")
+      allow(@appraisal).to receive(:project_root).
+        and_return(Pathname.new("/home/test"))
       allow(Appraisal::Command).to receive(:new).and_return(double(:run => true))
     end
 
@@ -65,6 +67,13 @@ describe Appraisal::Appraisal do
         with("#{bundle_check_command} || #{bundle_install_command_with_retries}")
     end
 
+    it "runs install command with path on Bundler" do
+      @appraisal.install("path" => "vendor/appraisal")
+
+      expect(Appraisal::Command).to have_received(:new).
+        with("#{bundle_check_command} || #{bundle_install_command_with_path}")
+    end
+
     def bundle_check_command
       "bundle check --gemfile='/home/test/test directory'"
     end
@@ -79,6 +88,11 @@ describe Appraisal::Appraisal do
 
     def bundle_install_command_with_retries
       "bundle install --gemfile='/home/test/test directory' --retry 3"
+    end
+
+    def bundle_install_command_with_path
+      "bundle install --gemfile='/home/test/test directory' " \
+        "--path /home/test/vendor/appraisal"
     end
   end
 end


### PR DESCRIPTION
The `path` option is often used to cache dependencies on CI, and this
causing projects like [Administrate][1] to do unnecessary work.

It's important that we pass the absolute file path to `--path`, as
otherwise it's assumed to be inside the `gemfiles` directory when run.

[1]: https://github.com/thoughtbot/administrate/pull/1482