### PR TITLE
Test against Ruby 2.4, 2.5, 2.6, 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-before_install: gem install bundler
+before_install: gem install bundler:1.17.3
 
 rvm:
   - 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+---
 before_install: gem install bundler
 
 rvm:
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby-9.2.9.0
   - ruby-head
   - jruby-head


### PR DESCRIPTION
This is bumping the patch releases to the current (as of 2020-02-10) and
introducing 2.6 and 2.7 of MRI Ruby.