### PR TITLE
(#170) Add ability to remove gem from appraisal

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,45 @@ When you prefix a command with `appraisal`, the command is run with the
 appropriate Gemfile for that appraisal, ensuring the correct dependencies
 are used.
 
+Removing Gems using Appraisal
+-------
+
+It is common while managing multiple Gemfiles for dependencies to become deprecated and no
+longer necessary, meaning they need to be removed from the Gemfile for a specific `appraisal`.
+To do this, use the `remove_gem` declaration within the necessary `appraise` block in your
+`Appraisals` file.
+
+### Example Usage
+**Gemfile**
+```ruby
+gem 'rails', '~> 4.2'
+
+group :test do
+  gem 'rspec', '~> 4.0'
+  gem 'test_after_commit'
+end
+```
+
+**Appriasals**
+```ruby
+appraise 'rails-5' do
+  gem 'rails', '~> 5.2'
+
+  group :test do
+    remove_gem :test_after_commit
+  end
+end
+```
+
+Using the `Appraisals` file defined above, this is what the resulting `Gemfile` will look like:
+```ruby
+gem 'rails', '~> 5.2'
+
+group :test do
+  gem 'rspec', '~> 4.0'
+end
+```
+
 Version Control
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ To do this, use the `remove_gem` declaration within the necessary `appraise` blo
 `Appraisals` file.
 
 ### Example Usage
+### Example Usage
+
 **Gemfile**
 ```ruby
 gem 'rails', '~> 4.2'
@@ -134,7 +136,7 @@ group :test do
 end
 ```
 
-**Appriasals**
+**Appraisals**
 ```ruby
 appraise 'rails-5' do
   gem 'rails', '~> 5.2'

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ To do this, use the `remove_gem` declaration within the necessary `appraise` blo
 `Appraisals` file.
 
 ### Example Usage
-### Example Usage
 
 **Gemfile**
 ```ruby

--- a/lib/appraisal/appraisal.rb
+++ b/lib/appraisal/appraisal.rb
@@ -20,6 +20,10 @@ module Appraisal
       gemfile.gem(*args)
     end
 
+    def remove_gem(*args)
+      gemfile.remove_gem(*args)
+    end
+
     def source(*args, &block)
       gemfile.source(*args, &block)
     end

--- a/lib/appraisal/bundler_dsl.rb
+++ b/lib/appraisal/bundler_dsl.rb
@@ -25,7 +25,11 @@ module Appraisal
     end
 
     def gem(name, *requirements)
-      @dependencies.add(name, substitute_git_source(requirements))
+      if requirements.include?(:remove)
+        @dependencies.remove(name)
+      else
+        @dependencies.add(name, substitute_git_source(requirements))
+      end
     end
 
     def group(*names, &block)

--- a/lib/appraisal/bundler_dsl.rb
+++ b/lib/appraisal/bundler_dsl.rb
@@ -25,11 +25,11 @@ module Appraisal
     end
 
     def gem(name, *requirements)
-      if requirements.include?(:remove)
-        @dependencies.remove(name)
-      else
-        @dependencies.add(name, substitute_git_source(requirements))
-      end
+      @dependencies.add(name, substitute_git_source(requirements))
+    end
+
+    def remove_gem(name)
+      @dependencies.remove(name)
     end
 
     def group(*names, &block)

--- a/lib/appraisal/dependency_list.rb
+++ b/lib/appraisal/dependency_list.rb
@@ -4,10 +4,19 @@ module Appraisal
   class DependencyList
     def initialize
       @dependencies = Hash.new
+      @removed_dependencies = Set.new
     end
 
     def add(name, requirements)
-      @dependencies[name] = Dependency.new(name, requirements)
+      unless @removed_dependencies.include?(name)
+        @dependencies[name] = Dependency.new(name, requirements)
+      end
+    end
+
+    def remove(name)
+      if @removed_dependencies.add?(name)
+        @dependencies.delete(name)
+      end
     end
 
     def to_s

--- a/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
+++ b/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'Appraisals file Bundler DSL compatibility' do
   it 'supports all Bundler DSL in Appraisals file' do
-    build_gems %w(bagel orange_juice milk waffle coffee ham sausage pancake rotten_egg)
+    build_gems %w(bagel orange_juice milk waffle coffee ham
+      sausage pancake rotten_egg)
     build_git_gems %w(egg croissant pain_au_chocolat omelette)
 
     build_gemfile <<-Gemfile

--- a/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
+++ b/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Appraisals file Bundler DSL compatibility' do
   it 'supports all Bundler DSL in Appraisals file' do
-    build_gems %w(bagel orange_juice milk waffle coffee ham sausage pancake)
+    build_gems %w(bagel orange_juice milk waffle coffee ham sausage pancake rotten_egg)
     build_git_gems %w(egg croissant pain_au_chocolat omelette)
 
     build_gemfile <<-Gemfile
@@ -24,6 +24,7 @@ describe 'Appraisals file Bundler DSL compatibility' do
       group :breakfast do
         gem 'orange_juice'
         gem "omelette", :custom_git_source => "omelette"
+        gem 'rotten_egg'
       end
 
       platforms :ruby, :jruby do
@@ -58,6 +59,7 @@ describe 'Appraisals file Bundler DSL compatibility' do
         end
 
         group :breakfast do
+          gem 'rotten_egg', :remove
           gem 'bacon'
 
           platforms :rbx do

--- a/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
+++ b/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
@@ -60,7 +60,7 @@ describe 'Appraisals file Bundler DSL compatibility' do
         end
 
         group :breakfast do
-          gem 'rotten_egg', :remove
+          remove_gem 'rotten_egg'
           gem 'bacon'
 
           platforms :rbx do

--- a/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
+++ b/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Appraisals file Bundler DSL compatibility' do
   it 'supports all Bundler DSL in Appraisals file' do
     build_gems %w(bagel orange_juice milk waffle coffee ham
-      sausage pancake rotten_egg)
+                  sausage pancake rotten_egg)
     build_git_gems %w(egg croissant pain_au_chocolat omelette)
 
     build_gemfile <<-Gemfile

--- a/spec/appraisal/dependency_list_spec.rb
+++ b/spec/appraisal/dependency_list_spec.rb
@@ -28,4 +28,23 @@ describe Appraisal::DependencyList do
       expect(dependency_list.to_s).to eq %(gem "rails", "4.1.4")
     end
   end
+
+  describe "#remove" do
+    let(:dependency_list) { Appraisal::DependencyList.new }
+
+    before do
+      dependency_list.add("rails", ["4.1.4"])
+    end
+
+    it "removes the dependency from the list" do
+      dependency_list.remove("rails")
+      expect(dependency_list.to_s).to eq("")
+    end
+
+    it "respects the removal over an addition" do
+      dependency_list.remove("rails")
+      dependency_list.add("rails", ["4.1.0"])
+      expect(dependency_list.to_s).to eq("")
+    end
+  end
 end


### PR DESCRIPTION
## Purpose of PR
This is adding the ability to use the `remove_gem` declaration within an `appraise` block. By doing so the gem will be dropped from the generated Gemfile.  This is useful in cases where an appraisal require the removal of old dependencies that are still used by the mainline source.

## Example Usage
**Gemfile**
```ruby
gem 'rails', '~> 4.2'

group :test do
  gem 'rspec', '~> 4.0'
  gem 'test_after_commit'
end
```

**Appraisals**
```ruby
appraise 'rails-5' do
  gem 'rails', '~> 5.2'

  group :test do
    remove_gem 'test_after_commit'
  end
end
```

To produce:
**gemfiles/rails_5.gemfile**
```ruby
gem 'rails', '~> 5.2'

group :test do
  gem 'rspec', '~> 4.0'
end
```

Fixes #170 

