### PR TITLE
Use bundler original env when running bundle commands. Fixes #173

### DIFF
--- a/lib/appraisal/command.rb
+++ b/lib/appraisal/command.rb
@@ -16,8 +16,8 @@ module Appraisal
         ensure_bundler_is_available
         announce
 
-        ENV['BUNDLE_GEMFILE'] = gemfile
-        ENV['APPRAISAL_INITIALIZED'] = '1'
+        ENV["BUNDLE_GEMFILE"] = gemfile
+        ENV["APPRAISAL_INITIALIZED"] = "1"
         env.each_pair do |key, value|
           ENV[key] = value
         end

--- a/lib/appraisal/command.rb
+++ b/lib/appraisal/command.rb
@@ -3,22 +3,21 @@ require "shellwords"
 module Appraisal
   # Executes commands with a clean environment
   class Command
-    BUNDLER_ENV_VARS = %w(RUBYOPT BUNDLE_PATH BUNDLE_BIN_PATH BUNDLE_GEMFILE).freeze
-
-    attr_reader :command, :env, :gemfile, :original_env
+    attr_reader :command, :env, :gemfile
 
     def initialize(command, options = {})
       @gemfile = options[:gemfile]
       @env = options.fetch(:env, {})
       @command = command_starting_with_bundle(command)
-      @original_env = {}
     end
 
     def run
-      with_clean_env { ensure_bundler_is_available }
-      announce
+      Bundler.with_original_env do
+        ensure_bundler_is_available
+        announce
 
-      with_clean_env do
+        ENV['BUNDLE_GEMFILE'] = gemfile
+        ENV['APPRAISAL_INITIALIZED'] = '1'
         env.each_pair do |key, value|
           ENV[key] = value
         end
@@ -30,15 +29,6 @@ module Appraisal
     end
 
     private
-
-    def with_clean_env
-      unset_bundler_env_vars
-      ENV['BUNDLE_GEMFILE'] = gemfile
-      ENV['APPRAISAL_INITIALIZED'] = '1'
-      yield
-    ensure
-      restore_env
-    end
 
     def ensure_bundler_is_available
       version = Utils.bundler_version
@@ -64,17 +54,6 @@ module Appraisal
       else
         puts ">> #{command_as_string}"
       end
-    end
-
-    def unset_bundler_env_vars
-      BUNDLER_ENV_VARS.each do |key|
-        original_env[key] = ENV[key]
-        ENV[key] = nil
-      end
-    end
-
-    def restore_env
-      original_env.each { |key, value| ENV[key] = value }
     end
 
     def command_starts_with_bundle?(original_command)


### PR DESCRIPTION
This PR fixes the situation when you've got something like a path config set in bundler.

```
± bundle config path vendor/bundle

± bundle exec appraisal
true
>> bundle check --gemfile='/Users/chris/code/acts_as_tenant/gemfiles/rails_5.gemfile' || bundle install --gemfile='/Users/chris/code/acts_as_tenant/gemfiles/rails_5.gemfile' --retry 1
Traceback (most recent call last):
	1: from /Users/chris/.asdf/installs/ruby/2.7.2/bin/bundle:23:in `<main>'
/Users/chris/.asdf/installs/ruby/2.7.2/bin/bundle:23:in `load': cannot load such file -- /Users/chris/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle (LoadError)
Traceback (most recent call last):
	1: from /Users/chris/.asdf/installs/ruby/2.7.2/bin/bundle:23:in `<main>'
/Users/chris/.asdf/installs/ruby/2.7.2/bin/bundle:23:in `load': cannot load such file -- /Users/chris/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle (LoadError)
```

Removing RUBYOPT when resetting the ENV fixes the above, however we can use the built-in Bundler helper instead to properly clean it for sub-commands.

Fixes #173 