### PR TITLE
Implement Bundler install_if

### DIFF
--- a/lib/appraisal/appraisal.rb
+++ b/lib/appraisal/appraisal.rb
@@ -44,6 +44,10 @@ module Appraisal
       gemfile.group(*args, &block)
     end
 
+    def install_if(*args, &block)
+      gemfile.install_if(*args, &block)
+    end
+
     def platforms(*args, &block)
       gemfile.platforms(*args, &block)
     end

--- a/lib/appraisal/bundler_dsl.rb
+++ b/lib/appraisal/bundler_dsl.rb
@@ -5,7 +5,7 @@ module Appraisal
     attr_reader :dependencies
 
     PARTS = %w(source ruby_version gits paths dependencies groups
-      platforms source_blocks install_if gemspec)
+               platforms source_blocks install_if gemspec)
 
     def initialize
       @sources = []
@@ -131,7 +131,7 @@ module Appraisal
       @dependencies.for_dup
     end
 
-    [:gits, :paths, :platforms, :groups, :source_blocks, :install_if].
+    %i[gits paths platforms groups source_blocks install_if].
       each do |method_name|
       class_eval <<-METHODS, __FILE__, __LINE__
         private

--- a/lib/appraisal/bundler_dsl.rb
+++ b/lib/appraisal/bundler_dsl.rb
@@ -5,7 +5,7 @@ module Appraisal
     attr_reader :dependencies
 
     PARTS = %w(source ruby_version gits paths dependencies groups
-      platforms source_blocks gemspec)
+      platforms source_blocks install_if gemspec)
 
     def initialize
       @sources = []
@@ -18,6 +18,7 @@ module Appraisal
       @paths = Hash.new
       @source_blocks = Hash.new
       @git_sources = {}
+      @install_if = {}
     end
 
     def run(&block)
@@ -36,6 +37,12 @@ module Appraisal
       @groups[names] ||=
         Group.new(names).tap { |g| g.git_sources = @git_sources.dup }
       @groups[names].run(&block)
+    end
+
+    def install_if(condition, &block)
+      @install_if[condition] ||=
+        Conditional.new(condition).tap { |g| g.git_sources = @git_sources.dup }
+      @install_if[condition].run(&block)
     end
 
     def platforms(*names, &block)
@@ -124,7 +131,7 @@ module Appraisal
       @dependencies.for_dup
     end
 
-    [:gits, :paths, :platforms, :groups, :source_blocks].
+    [:gits, :paths, :platforms, :groups, :source_blocks, :install_if].
       each do |method_name|
       class_eval <<-METHODS, __FILE__, __LINE__
         private

--- a/lib/appraisal/conditional.rb
+++ b/lib/appraisal/conditional.rb
@@ -1,0 +1,20 @@
+require "appraisal/bundler_dsl"
+require "appraisal/utils"
+
+module Appraisal
+  class Conditional < BundlerDSL
+    def initialize(condition)
+      super()
+      @condition = condition
+    end
+
+    def to_s
+      "install_if #{@condition} do\n#{indent(super)}\nend"
+    end
+
+    # :nodoc:
+    def for_dup
+      "install_if #{@condition} do\n#{indent(super)}\nend"
+    end
+  end
+end

--- a/lib/appraisal/gemfile.rb
+++ b/lib/appraisal/gemfile.rb
@@ -7,6 +7,7 @@ module Appraisal
   autoload :Path, "appraisal/path"
   autoload :Platform, "appraisal/platform"
   autoload :Source, "appraisal/source"
+  autoload :Conditional, "appraisal/conditional"
 
   # Load bundler Gemfiles and merge dependencies
   class Gemfile < BundlerDSL

--- a/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
+++ b/spec/acceptance/appraisals_file_bundler_dsl_compatibility_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Appraisals file Bundler DSL compatibility' do
   it 'supports all Bundler DSL in Appraisals file' do
     build_gems %w(bagel orange_juice milk waffle coffee ham
-                  sausage pancake rotten_egg)
+                  sausage pancake rotten_egg mayonnaise)
     build_git_gems %w(egg croissant pain_au_chocolat omelette)
 
     build_gemfile <<-Gemfile
@@ -40,6 +40,10 @@ describe 'Appraisals file Bundler DSL compatibility' do
         gem "sausage"
       end
 
+      install_if '"-> { true }"' do
+        gem 'mayonnaise'
+      end
+
       gem 'appraisal', :path => #{PROJECT_ROOT.inspect}
     Gemfile
 
@@ -74,6 +78,10 @@ describe 'Appraisals file Bundler DSL compatibility' do
 
         source "https://other-rubygems.org" do
           gem "pancake"
+        end
+
+        install_if "-> { true }" do
+          gem 'ketchup'
         end
 
         gemspec
@@ -130,6 +138,11 @@ describe 'Appraisals file Bundler DSL compatibility' do
       source "https://other-rubygems.org" do
         gem "sausage"
         gem "pancake"
+      end
+
+      install_if -> { true } do
+        gem "mayonnaise"
+        gem "ketchup"
       end
 
       gemspec :path => "../"


### PR DESCRIPTION
This an attempt to fix: https://github.com/thoughtbot/appraisal/issues/131

The trick here is to store the conditional as plain string. As explained here https://github.com/thoughtbot/appraisal/pull/132#discussion_r154461946 :

> We dont want the lambda evaluated on generate, we want it evaluated on bundle install. No idea how to do that and im too pneumonia sick to think :D

IMHO the easiest way is to write/store it as a string and render it directly in the generated file (verbatim).

So in `Appraisal` file :

```ruby
install_if -> { ENV["DB_ADAPTER"] == "mysql2" } do
  gem 'mysql'
end
```

becomes 

```ruby
install_if '-> { ENV["DB_ADAPTER"] == "mysql2" }' do
  gem 'mysql'
end
```
After generation it becomes (in `gemfiles/*.gemfile`) :

```ruby
install_if -> { ENV["DB_ADAPTER"] == "mysql2" } do
  gem 'mysql'
end
```
It should help to solve most use cases since you can put any valid Ruby code here :).

At first I tried https://github.com/banister/method_source but it immediately failed. 

Because :

> Cannot return source for dynamically defined methods.

So I ended up with this easy solution that does the job.