### PR TITLE
Silence `gem list` command output

### DIFF
--- a/lib/appraisal/command.rb
+++ b/lib/appraisal/command.rb
@@ -42,7 +42,7 @@ module Appraisal
 
     def ensure_bundler_is_available
       version = Utils.bundler_version
-      unless system %(gem list -i bundler -v #{version})
+      unless system %(gem list --silent -i bundler -v #{version})
         puts ">> Reinstall Bundler into #{ENV["GEM_HOME"]}"
 
         unless system "gem install bundler --version #{version}"


### PR DESCRIPTION
Prevents `appraisal rake` to write a boolean on the standard output when
checking the installed version of bundler

Bug introduced in #168 586864393e405a67b1457b563a4d5adc99e50e2d

Fix: #180