### PR TITLE
Allow JRuby to fail on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ rvm:
 matrix:
   fast_finish: true
   allow_failures:
+    - rvm: jruby-9.2.9.0
     - rvm: ruby-head
     - rvm: jruby-head


### PR DESCRIPTION
We should restore support for JRuby in the future, but it is better to
acknowledge that it's not currently a priority because of other issues
in Appraisal, as it's not something that will be fixed soon.