### PR TITLE
Explicit require for Set

### DIFF
--- a/lib/appraisal/dependency_list.rb
+++ b/lib/appraisal/dependency_list.rb
@@ -1,4 +1,5 @@
 require 'appraisal/dependency'
+require "set"
 
 module Appraisal
   class DependencyList


### PR DESCRIPTION
As `rake` moved their `require "set"'"` statement in [`13.0.4`#diff-191505f9c8](https://github.com/ruby/rake/compare/v13.0.3...v13.0.4#diff-191505f9c8c2ec5e7e334d28ce7e466da7fa7f12e3795482cc2fa71b4e2d3159L2) today, `appraisal install` started to fail with the error:
```
$ bundle exec appraisal install
bundler: failed to load command: appraisal (/app/bin/appraisal)
/app/gems/appraisal-2.4.0/lib/appraisal/dependency_list.rb:7:in `initialize': uninitialized constant Appraisal::DependencyList::Set (NameError)
	from /app/gems/appraisal-2.4.0/lib/appraisal/bundler_dsl.rb:13:in `new'
	from /app/gems/appraisal-2.4.0/lib/appraisal/bundler_dsl.rb:13:in `initialize'
	from /app/gems/appraisal-2.4.0/lib/appraisal/appraisal_file.rb:16:in `new'
	from /app/gems/appraisal-2.4.0/lib/appraisal/appraisal_file.rb:16:in `initialize'
	from /app/gems/appraisal-2.4.0/lib/appraisal/appraisal_file.rb:11:in `new'
	from /app/gems/appraisal-2.4.0/lib/appraisal/appraisal_file.rb:11:in `each'
	from /app/gems/appraisal-2.4.0/lib/appraisal/task.rb:32:in `block in initialize'
	from /app/gems/rake-13.0.4/lib/rake/task_manager.rb:232:in `in_namespace'
	from /app/gems/rake-13.0.4/lib/rake/dsl_definition.rb:141:in `namespace'
	from /app/gems/appraisal-2.4.0/lib/appraisal/task.rb:9:in `initialize'
	from /app/gems/appraisal-2.4.0/lib/appraisal.rb:4:in `new'
	from /app/gems/appraisal-2.4.0/lib/appraisal.rb:4:in `<top (required)>'
	from /app/gems/appraisal-2.4.0/bin/appraisal:4:in `require'
	from /app/gems/appraisal-2.4.0/bin/appraisal:4:in `<top (required)>'
	from /app/bin/appraisal:23:in `load'
	from /app/bin/appraisal:23:in `<top (required)>'
	from /app/gems/bundler-2.2.19/lib/bundler/cli/exec.rb:63:in `load'
	from /app/gems/bundler-2.2.19/lib/bundler/cli/exec.rb:63:in `kernel_load'
	from /app/gems/bundler-2.2.19/lib/bundler/cli/exec.rb:28:in `run'
	from /app/gems/bundler-2.2.19/lib/bundler/cli.rb:474:in `exec'
	from /app/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /app/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /app/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /app/gems/bundler-2.2.19/lib/bundler/cli.rb:30:in `dispatch'
	from /app/gems/bundler-2.2.19/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /app/gems/bundler-2.2.19/lib/bundler/cli.rb:24:in `start'
	from /app/gems/bundler-2.2.19/exe/bundle:49:in `block in <top (required)>'
	from /app/gems/bundler-2.2.19/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	from /app/gems/bundler-2.2.19/exe/bundle:37:in `<top (required)>'
	from /app/bin/bundle:23:in `load'
	from /app/bin/bundle:23:in `<main>'
```

This fails for any `Appraisals` file.

This affects Ruby 2.4 up to 3.0, as far as I could test.

This PR adds the `require 'set'` statement to the file that references the `Set` class.