### PR TITLE
Fix `__FILE__` and `__dir__` in primary Gemfiles

### DIFF
--- a/lib/appraisal/gemfile.rb
+++ b/lib/appraisal/gemfile.rb
@@ -12,19 +12,17 @@ module Appraisal
   # Load bundler Gemfiles and merge dependencies
   class Gemfile < BundlerDSL
     def load(path)
-      if File.exist?(path)
-        run(IO.read(path))
-      end
+      run(IO.read(path), path) if File.exist?(path)
     end
 
-    def run(definitions)
-      instance_eval(definitions, __FILE__, __LINE__) if definitions
+    def run(definitions, path, line = 1)
+      instance_eval(definitions, path, line) if definitions
     end
 
     def dup
       Gemfile.new.tap do |gemfile|
         gemfile.git_sources = @git_sources
-        gemfile.run(for_dup)
+        gemfile.run(for_dup, __FILE__, __LINE__)
       end
     end
   end

--- a/spec/appraisal/gemfile_spec.rb
+++ b/spec/appraisal/gemfile_spec.rb
@@ -430,4 +430,13 @@ describe Appraisal::Gemfile do
       expect(gemfile.to_s).to eq %(gem "bacon", git: "../path/bacon_pancake")
     end
   end
+
+  it "preserves the Gemfile's __FILE__" do
+    gemfile = Appraisal::Gemfile.new
+    Tempfile.open do |tmpfile|
+      tmpfile.write "__FILE__"
+      tmpfile.rewind
+      expect(gemfile.load(tmpfile.path)).to include(File.dirname(tmpfile.path))
+    end
+  end
 end


### PR DESCRIPTION
Appraisal is good! I found a bug: I have the habit of using `ruby Pathname.new(__dir__).join(".ruby-version").read` in my `Gemfile`, so that I can write my ruby version in just one place, in the `.ruby-version` file.

Unfortunately, the Gemfile classes calls `instance_eval` without telling Ruby what file the string came from, and so Ruby thinks that __FILE__ should point to appraisal/lib/appraisal/gemfile.rb instead of the Gemfile itself, and that breaks anything inside the Gemfile that references either `__FILE__` or `__dir__`.

This PR adds a test and passes in the path to the Gemfile, if it is known, to fix that.