### PR TITLE
Run specs with bundler 2.3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-before_install: gem install bundler:2.1.4
+before_install: gem install bundler:2.3.7
 
 rvm:
   - 2.3


### PR DESCRIPTION
I tried running specs with the latest version of bundler and everything went fine except for a small change in `bundle install` output.