### PR TITLE
Fixed broken logo on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ command in the `override` section and use your favourite one.
 Credits
 -------
 
-![thoughtbot](http://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg)
+![thoughtbot](https://thoughtbot.com/thoughtbot-logo-for-readmes.svg)
 
 Appraisal is maintained and funded by [thoughtbot, inc][thoughtbot]
 


### PR DESCRIPTION
Addresses a broken image on the homepage:

<img width="583" alt="image" src="https://user-images.githubusercontent.com/10163/205462726-d0f719ab-bc65-4cac-818a-9ff0c05cfcf1.png">
