### PR TITLE
Use Bundler.with_original_env instead of custom clean environment logic

### DIFF
--- a/spec/acceptance/bundle_without_spec.rb
+++ b/spec/acceptance/bundle_without_spec.rb
@@ -39,7 +39,9 @@ describe "Bundler without flag" do
     output = run "appraisal install --without drinks"
 
     expect(output).to include("Bundle complete")
-    expect(output).to include("Gems in the group drinks were not installed.")
+    expect(output).to(
+      match(/Gems in the group ['"]?drinks['"]? were not installed/),
+    )
     expect(output).not_to include("orange_juice")
     expect(output).not_to include("coffee")
     expect(output).not_to include("soda")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "./spec/support/stream_helpers"
 
 PROJECT_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..')).freeze
 TMP_GEM_ROOT = File.join(PROJECT_ROOT, "tmp", "gems")
+ENV["APPRAISAL_UNDER_TEST"] = "1"
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
This is simply a version of #174 that:

1. Is rebased on the most recent `main`
2. Has tests that actually pass

(2) is done by way of introducing a new  'APPRAISAL_UNDER_TEST' environment variable that `Command` uses to determine if Appraisal itself is under test, and if so, tweaks the environment in the way the tests require.