### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.2, jruby-9.3, jruby-9.4, ruby-head, jruby-head]
+
+    name: Specs - Ruby ${{ matrix.ruby-version }}
+    steps:
+    - name: Set git to master
+      run: git config --global init.defaultBranch master
+    - uses: actions/checkout@v3
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # 'bundle install' and cache
+        rubygems: latest
+    - name: Run tests
+      run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ generates within the gemfiles directory, but exclude the lockfiles there
 (`*.gemfile.lock`.) The Gemfiles are useful when running your tests against a
 continuous integration server.
 
+
 Circle CI Integration
 ---------------------
 

--- a/spec/support/acceptance_test_helpers.rb
+++ b/spec/support/acceptance_test_helpers.rb
@@ -128,7 +128,7 @@ module AcceptanceTestHelpers
         Reinstall Bundler to #{TMP_GEM_ROOT} as `BUNDLE_DISABLE_SHARED_GEMS`
         is enabled.
       WARNING
-      version = Utils.bundler_version
+      version = Appraisal::Utils.bundler_version
 
       run "gem install bundler --version #{version} --install-dir '#{TMP_GEM_ROOT}'"
     end


### PR DESCRIPTION
As Travis CI.org has been inactive since mid-2021, appraisal has not had CI for quite some time.  This PR is an attempt to migrate CI to GitHub actions.

It is not green, and I'm looking for help on getting it there.  The current failures are all `bundler` install issues.  Is anyone more familiar with the internals of the `appraisal` gem able to give me some guidance on how to get the `bundle install --local` in the various specs to pass?  Do we need to set an environment variable?  Or is this unrelated to current work?