### PR TITLE
Split binstubs from accepance test helpers install

### DIFF
--- a/spec/support/acceptance_test_helpers.rb
+++ b/spec/support/acceptance_test_helpers.rb
@@ -141,7 +141,8 @@ module AcceptanceTestHelpers
       gem 'appraisal', :path => '#{PROJECT_ROOT}'
     Gemfile
 
-    run "bundle install --binstubs --local"
+    run "bundle install --local"
+    run "bundle binstubs --all"
   end
 
   def in_test_directory(&block)


### PR DESCRIPTION
Passing along `--binstubs` is deprecationed and outputs a lot of warnings. This is good enough and doesn't need further adjustments.