### PR TITLE
Fix `customize_gemfiles` on Ruby 3

### DIFF
--- a/lib/appraisal/appraisal_file.rb
+++ b/lib/appraisal/appraisal_file.rb
@@ -35,7 +35,7 @@ module Appraisal
     end
 
     def customize_gemfiles(&_block)
-      Customize.new(yield)
+      Customize.new(**yield)
     end
 
     private

--- a/spec/appraisal/appraisal_file_spec.rb
+++ b/spec/appraisal/appraisal_file_spec.rb
@@ -11,4 +11,59 @@ describe Appraisal::AppraisalFile do
     allow(File).to receive(:exist?).with("Appraisals").and_return(false)
     expect { described_class.new }.to raise_error(Appraisal::AppraisalsNotFound)
   end
+
+  describe '#customize_gemfiles' do
+    before(:each) do
+      allow(File).to receive(:exist?).with(anything).and_return(true)
+      allow(IO).to receive(:read).with(anything).and_return("")
+    end
+
+    context 'when no arguments are given' do
+      subject { described_class.new.customize_gemfiles }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(LocalJumpError)
+      end
+    end
+
+    context 'when a block is given' do
+      context 'when the block returns a hash with :heading key' do
+        subject do
+          described_class.new.customize_gemfiles do
+            { heading: 'foo' }
+          end
+        end
+
+        it 'sets the heading' do
+          expect { subject }.to change { Appraisal::Customize.heading }.to('foo')
+        end
+      end
+
+      context 'when the block returns a hash with :single_quotes key' do
+        subject do
+          described_class.new.customize_gemfiles do
+            { single_quotes: true }
+          end
+        end
+
+        it 'sets the single_quotes' do
+          expect { subject }.to change { Appraisal::Customize.single_quotes }.to(true)
+        end
+      end
+
+      context 'when the block returns a hash with :heading and :single_quotes keys' do
+        subject do
+          described_class.new.customize_gemfiles do
+            { heading: 'foo', single_quotes: true }
+          end
+        end
+
+        it 'sets the heading and single_quotes' do
+          subject
+          expect(Appraisal::Customize.heading).to eq('foo')
+          expect(Appraisal::Customize.single_quotes).to eq(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/appraisal/appraisal_file_spec.rb
+++ b/spec/appraisal/appraisal_file_spec.rb
@@ -12,55 +12,55 @@ describe Appraisal::AppraisalFile do
     expect { described_class.new }.to raise_error(Appraisal::AppraisalsNotFound)
   end
 
-  describe '#customize_gemfiles' do
+  describe "#customize_gemfiles" do
     before(:each) do
       allow(File).to receive(:exist?).with(anything).and_return(true)
       allow(IO).to receive(:read).with(anything).and_return("")
     end
 
-    context 'when no arguments are given' do
+    context "when no arguments are given" do
       subject { described_class.new.customize_gemfiles }
 
-      it 'raises an error' do
+      it "raises an error" do
         expect { subject }.to raise_error(LocalJumpError)
       end
     end
 
-    context 'when a block is given' do
-      context 'when the block returns a hash with :heading key' do
+    context "when a block is given" do
+      context "when the block returns a hash with :heading key" do
         subject do
           described_class.new.customize_gemfiles do
-            { heading: 'foo' }
+            { heading: "foo" }
           end
         end
 
-        it 'sets the heading' do
-          expect { subject }.to change { Appraisal::Customize.heading }.to('foo')
+        it "sets the heading" do
+          expect { subject }.to change { Appraisal::Customize.heading }.to("foo")
         end
       end
 
-      context 'when the block returns a hash with :single_quotes key' do
+      context "when the block returns a hash with :single_quotes key" do
         subject do
           described_class.new.customize_gemfiles do
             { single_quotes: true }
           end
         end
 
-        it 'sets the single_quotes' do
+        it "sets the single_quotes" do
           expect { subject }.to change { Appraisal::Customize.single_quotes }.to(true)
         end
       end
 
-      context 'when the block returns a hash with :heading and :single_quotes keys' do
+      context "when the block returns a hash with :heading and :single_quotes keys" do
         subject do
           described_class.new.customize_gemfiles do
-            { heading: 'foo', single_quotes: true }
+            { heading: "foo", single_quotes: true }
           end
         end
 
-        it 'sets the heading and single_quotes' do
+        it "sets the heading and single_quotes" do
           subject
-          expect(Appraisal::Customize.heading).to eq('foo')
+          expect(Appraisal::Customize.heading).to eq("foo")
           expect(Appraisal::Customize.single_quotes).to eq(true)
         end
       end


### PR DESCRIPTION
# Summary

https://github.com/thoughtbot/appraisal/pull/191 added an ability to customize headers in gemfiles generated by Appraisal, as well as creating the strings using single quotes. But there's a small bug with the implementation that prevents it from working on Ruby 3:

```ruby
def customize_gemfiles(&_block)
  Customize.new(yield)
end
```

With changes in Ruby 3, the Hash `yield`'ed from the block needs to be converted into keyword arguments with `**`.
This PR resolves the issue and provides tests to validate this behaviour.

This addresses #213.