### PR TITLE
Make tests more resilient in different git environments

### DIFF
--- a/spec/support/dependency_helpers.rb
+++ b/spec/support/dependency_helpers.rb
@@ -39,11 +39,11 @@ module DependencyHelpers
     build_gem gem_name, version
 
     Dir.chdir "tmp/gems/#{gem_name}" do
-      `git init .`
+      `git init . --initial-branch=master`
       `git config user.email "appraisal@thoughtbot.com"`
       `git config user.name "Appraisal"`
       `git add .`
-      `git commit -a -m "initial commit"`
+      `git commit --all --no-verify --message "initial commit"`
     end
 
     # Cleanup Bundler cache path manually for now


### PR DESCRIPTION
# Summary

While working on this repository, a couple of issues sprung up on me that required me to modify my current `git` configuration to make sure that specs run properly:

1. Bundler depends on the fact that gems generated for the purpose of a test have a `master` branch. If someone has an `init.defaultBranch = main` configuration in git, this will cause those temporary repositories with temporary gems to not have a `master` branch, failing a test.
2. To create a proper repository, tests create an initial commit using `git commit`, which launches a `pre-commit` hook by default. If someone has a `core.hooksPath` variable set in their global git config, and if they have a global `pre-commit` hook, it will run on those repositories.

Since we're not testing how git works, and we're merely using it to create entities that we can use as stubs and dummies for testing, we don't need to trigger those features.

This PR edits dependency helpers to make it so that aforementioned local setup differences don't influence Appraisal testing.
