### PR TITLE
Fix remove_gem example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ appraise 'rails-5' do
   gem 'rails', '~> 5.2'
 
   group :test do
-    remove_gem :test_after_commit
+    remove_gem 'test_after_commit'
   end
 end
 ```


### PR DESCRIPTION
Was trying to take the `remove_gem` feature into use and got a bit mislead by the example in the readme. This little adjustment addresses that.