### PR TITLE
Avoid using the `--path` parameter to Bundler

### DIFF
--- a/spec/acceptance/bundle_with_custom_path_spec.rb
+++ b/spec/acceptance/bundle_with_custom_path_spec.rb
@@ -19,7 +19,8 @@ describe "Bundle with custom path" do
         end
       Appraisals
 
-      run %(bundle install --path="#{path}")
+      run "bundle config set --local path #{path}"
+      run "bundle install"
       run 'bundle exec appraisal install'
 
       installed_gem = Dir.glob("tmp/stage/#{path}/#{Gem.ruby_engine}/*/gems/*").
@@ -32,6 +33,8 @@ describe "Bundle with custom path" do
 
       appraisal_output = run 'bundle exec appraisal install'
       expect(appraisal_output).to include("The Gemfile's dependencies are satisfied")
+
+      run "bundle config unset --local path"
     end
   end
 
@@ -45,7 +48,9 @@ describe "Bundle with custom path" do
         gem '#{gem_name}'
       Gemfile
 
-      run 'bundle install --path vendor/another'
+      run "bundle config set --local path vendor/another"
+      run "bundle install"
+      run "bundle config unset --local path"
     end
 
     include_examples :gemfile_dependencies_are_satisfied


### PR DESCRIPTION
This has been deprecated in favour of setting the value via `config` instead. It was causing a deprecation warning and it's expected that it'll be removed in Bundler v3.

https://bundler.io/v2.5/man/bundle-config.1.html#REMEMBERING-OPTIONS