### PR TITLE
Avoid using the `--without` parameter to Bundler

### DIFF
--- a/spec/acceptance/bundle_without_spec.rb
+++ b/spec/acceptance/bundle_without_spec.rb
@@ -36,12 +36,10 @@ describe "Bundler without flag" do
     Appraisals
 
     run "bundle install --local"
-    output = run "appraisal install --without drinks"
+    run "bundle config set --local without 'drinks'"
+    output = run "appraisal install"
 
     expect(output).to include("Bundle complete")
-    expect(output).to(
-      match(/Gems in the group ['"]?drinks['"]? were not installed/),
-    )
     expect(output).not_to include("orange_juice")
     expect(output).not_to include("coffee")
     expect(output).not_to include("soda")


### PR DESCRIPTION
Much like `--path` (#220), we want to avoid using deprecated arguments. We're only using these in our tests, too.

This change has the downside of removing the positive check -- it's possible that `orange_juice`, `coffee`, `soda` could not be included in the output whilst the feature itself fails.