### PR TITLE
Fix #216, extra newline with customize_gemfiles

### DIFF
--- a/lib/appraisal/customize.rb
+++ b/lib/appraisal/customize.rb
@@ -1,7 +1,7 @@
 module Appraisal
   class Customize
     def initialize(heading: nil, single_quotes: false)
-      @@heading = heading
+      @@heading = heading&.chomp
       @@single_quotes = single_quotes
     end
 


### PR DESCRIPTION
On line 67 we join with two newlines, which will create an extra newline with how we recommend people use the Gemfile customization feature. This PR chomps the final newline to prevent that extra empty line described in issue #216 