### PR TITLE
Fix error when using Appraisal and install_if

### DIFF
--- a/lib/appraisal/conditional.rb
+++ b/lib/appraisal/conditional.rb
@@ -16,6 +16,8 @@ module Appraisal
 
     # :nodoc:
     def for_dup
+      return unless @condition.is_a?(String)
+
       "install_if #{@condition} do\n#{indent(super)}\nend"
     end
   end


### PR DESCRIPTION
```sh
An error occurred while loading ./spec/draper/draper_spec.rb.
Failure/Error: Bundler.require(*Rails.groups)

SyntaxError:
  /Users/nicolas/.asdf/installs/ruby/3.3.3/lib/ruby/gems/3.3.0/gems/appraisal-2.5.0/lib/appraisal/gemfile.rb:52: syntax error, unexpected `end'
# ./spec/dummy/config/application.rb:10:in `<top (required)>'
# ./spec/dummy/config/environment.rb:4:in `require_relative'
# ./spec/dummy/config/environment.rb:4:in `<top (required)>'
# ./spec/spec_helper.rb:12:in `<top (required)>'
# ./spec/draper/draper_spec.rb:1:in `<top (required)>'
```

I've added some debug around `def dup` (`puts YAML.dump(for_dup)` right before `gemfile.run(for_dup, __FILE__, __LINE__)` :

https://github.com/thoughtbot/appraisal/blob/be4fa01273dbff599e45a9ef0a3a04b89b23d920/lib/appraisal/gemfile.rb#L22-L26

Instead of using a raw String as explained here (https://github.com/thoughtbot/appraisal/pull/176) it uses the interpreted version:

```sh
--- |-
  source "https://rubygems.org"

  gem "appraisal"
  gem "capybara"
  gem "cuprite"
  gem "database_cleaner"
  gem "factory_bot"
  gem "faker"
  gem "guard-rspec"
  gem "puma"
  gem "rake"
  gem "rspec-rails"
  gem "rspec-retry"
  gem "rubocop"
  gem "rubocop-capybara"
  gem "rubocop-factory_bot"
  gem "rubocop-rake"
  gem "rubocop-rspec"
  gem "simplecov"
  gem "sqlite3", "~> 1.5.0"
  gem "rails", "6.1.7"

  install_if #<Proc:0x000000011f590cc0 /Users/nicolas/PROJECTS/CONCERTO/gems/draper/gemfiles/rails_6.1.7.gemfile:25 (lambda)> do
    gem "net-imap"
    gem "net-pop"
    gem "net-smtp"
  end

  install_if #<Proc:0x000000011f5909f0 /Users/nicolas/PROJECTS/CONCERTO/gems/draper/gemfiles/rails_6.1.7.gemfile:31 (lambda)> do
    gem "base64"
    gem "bigdecimal"
    gem "mutex_m"
    gem "drb"
    gem "logger"
  end

  gemspec path: "../"
```