### PR TITLE
Cleanup Bundler ENV variable introduced in Bundler 2.4

### DIFF
--- a/spec/support/acceptance_test_helpers.rb
+++ b/spec/support/acceptance_test_helpers.rb
@@ -9,8 +9,13 @@ module AcceptanceTestHelpers
   extend ActiveSupport::Concern
   include DependencyHelpers
 
-  BUNDLER_ENVIRONMENT_VARIABLES = %w(RUBYOPT BUNDLE_PATH BUNDLE_BIN_PATH
-    BUNDLE_GEMFILE)
+  BUNDLER_ENVIRONMENT_VARIABLES = %w(
+    RUBYOPT
+    BUNDLE_PATH
+    BUNDLE_BIN_PATH
+    BUNDLE_GEMFILE
+    BUNDLER_SETUP
+  ).freeze
 
   included do
     metadata[:type] = :acceptance


### PR DESCRIPTION
See https://github.com/rubygems/rubygems/pull/6025.

This gets most specs passing with the latest version of Bundler.

Closes https://github.com/thoughtbot/appraisal/issues/218.