### PR TITLE
Allow "ruby file:" syntax in gemfile

### DIFF
--- a/lib/appraisal/bundler_dsl.rb
+++ b/lib/appraisal/bundler_dsl.rb
@@ -65,8 +65,9 @@ module Appraisal
       end
     end
 
-    def ruby(ruby_version)
+    def ruby(ruby_version = nil, **kwargs)
       @ruby_version = ruby_version
+      @ruby_version = kwargs unless ruby_version
     end
 
     def git(source, options = {}, &block)

--- a/spec/appraisal/gemfile_spec.rb
+++ b/spec/appraisal/gemfile_spec.rb
@@ -440,4 +440,17 @@ RSpec.describe Appraisal::Gemfile do
       expect(gemfile.load(tmpfile.path)).to include(File.dirname(tmpfile.path))
     end
   end
+
+  it "supports the ruby file: syntax" do
+    gemfile = Appraisal::Gemfile.new
+
+    gemfile.ruby file: ".ruby-version"
+    gemfile.source "one"
+
+    expect(gemfile.to_s).to eq <<-GEMFILE.strip_heredoc.strip
+      source "one"
+
+      ruby {:file=>".ruby-version"}
+    GEMFILE
+  end
 end

--- a/spec/appraisal/gemfile_spec.rb
+++ b/spec/appraisal/gemfile_spec.rb
@@ -447,10 +447,13 @@ RSpec.describe Appraisal::Gemfile do
     gemfile.ruby file: ".ruby-version"
     gemfile.source "one"
 
+    ruby_version = gemfile.instance_variable_get("@ruby_version")
+    expected = ruby_version.is_a?(String) ? "ruby #{ruby_version.inspect}" : "ruby(#{ruby_version.inspect})"
+
     expect(gemfile.to_s).to eq <<-GEMFILE.strip_heredoc.strip
       source "one"
 
-      ruby {:file=>".ruby-version"}
+      #{expected}
     GEMFILE
   end
 end


### PR DESCRIPTION
Given in the gemfile the following ruby syntax is used:

```ruby
ruby file: "../.ruby-version"

…
```

Appraisal would fail with `wrong number of arguments (given 0, expected 1) (ArgumentError)`

```
…/appraisal-2.5.0/lib/appraisal/bundler_dsl.rb:66:in `ruby': wrong number of arguments (given 0, expected 1) (ArgumentError)
	from …/appraisal-2.5.0/lib/appraisal/gemfile.rb:27:in `run'
	from …/appraisal-2.5.0/lib/appraisal/gemfile.rb:19:in `instance_eval'
	from …/appraisal-2.5.0/lib/appraisal/gemfile.rb:19:in `run'
	from …/appraisal-2.5.0/lib/appraisal/gemfile.rb:25:in `block in dup'
…
```

This PR fixes this issue by allowing keyword arguments.

There is just one "visual" downsize that the syntax in the appraisal gemfiles is converted to Ruby 1.8 syntax:

```diff
-ruby file: ".ruby-version"
+ruby {:file=>".ruby-version"}
```

Not sure if this is a big issue. Could be probably ignored because it still works and is just some minor visual thing.